### PR TITLE
Added employeeId to appraisal form submission

### DIFF
--- a/resources/views/dashboard/test-employee-kpi-form.blade.php
+++ b/resources/views/dashboard/test-employee-kpi-form.blade.php
@@ -454,6 +454,8 @@
                                                 </h4>
                                                 <form action="{{ route('submit.appraisal') }}" method="POST">
                                                     @csrf
+                                                    <input type="hidden" name="employeeId"
+                                                        value="{{ $employeeId }}">
                                                     <input type="hidden" name="kpiId"
                                                         value="{{ $kpi->kpi->kpiId }}">
                                                     <input type="hidden" name="batchId"


### PR DESCRIPTION
Included a hidden input for employeeId in the appraisal form to ensure the employee's identifier is sent with the POST request. This change helps associate the appraisal data with the correct employee.